### PR TITLE
Align with TPEN messaging contract — opt into TPEN_HYDRATED_CONTEXT

### DIFF
--- a/main.js
+++ b/main.js
@@ -58,12 +58,6 @@ export class PromptsApp {
                 showAuthButton: true,
                 onRequestAuth: () => this.messages.requestAuthToken()
             })
-            // Request the hydrated payload eagerly. If the parent has already
-            // sent TPEN_CONTEXT before we wired up the listener, this kicks
-            // off the hydration handshake. If the listener fires first, the
-            // TPEN_CONTEXT branch will also request hydration — duplicate
-            // requests are cheap and idempotent on the parent side.
-            this.messages.requestHydratedContext()
         }
 
         await initTemplates()

--- a/main.js
+++ b/main.js
@@ -2,11 +2,12 @@
  * @file TPEN-Prompts orchestrator.
  *
  * Iframed mode: the parent pushes a lean `TPEN_CONTEXT` payload on iframe
- * load (project identity + URIs only). Prompt templates need fully-hydrated
+ * load (project identity + URIs only). Prompt templates need fully-populated
  * project/page/canvas objects, so on receipt of `TPEN_CONTEXT` we send
- * `REQUEST_HYDRATED_CONTEXT` upstream; the parent replies with
- * `TPEN_HYDRATED_CONTEXT` and the child renders from that payload.
- * The `TPEN_ID_TOKEN` flow remains user-gated and separate.
+ * `REQUEST_POPULATED_PROJECT` + `REQUEST_POPULATED_PAGE` upstream; the parent
+ * replies with `TPEN_POPULATED_PROJECT` and `TPEN_POPULATED_PAGE`, the
+ * MessageHandler accumulates both halves, and the child renders from the
+ * combined bundle. The `TPEN_ID_TOKEN` flow remains user-gated and separate.
  *
  * Standalone mode: reads URL params, fetches project (+ optionally page) from
  * the TPEN services API, resolves layer/column/line from the project graph.
@@ -38,8 +39,8 @@ export class PromptsApp {
 
     /**
      * Bootstrap the app. Iframed: show an awaiting screen and wait for the
-     * parent to push `TPEN_CONTEXT`, then request `TPEN_HYDRATED_CONTEXT`.
-     * Standalone: render the id-entry form (or load directly when
+     * parent to push `TPEN_CONTEXT`, then request the populated project/page
+     * pair. Standalone: render the id-entry form (or load directly when
      * `projectID` is in the URL).
      * @returns {Promise<void>}
      */
@@ -47,9 +48,9 @@ export class PromptsApp {
         const iframed = window.parent !== window
 
         // Paint the awaiting screen SYNCHRONOUSLY, before any await. Otherwise
-        // a `TPEN_HYDRATED_CONTEXT` message that lands during
-        // `await initTemplates()` renders the workspace, and then this init()
-        // continuation silently overwrites it with the awaiting screen.
+        // a populated-bundle flush that lands during `await initTemplates()`
+        // renders the workspace, and then this init() continuation silently
+        // overwrites it with the awaiting screen.
         if (iframed) {
             clearStoredToken()
             this.token = null
@@ -95,11 +96,11 @@ export class PromptsApp {
     }
 
     /**
-     * Accept a `TPEN_HYDRATED_CONTEXT` payload from the parent. The payload
-     * is expected to carry hydrated `project`, `page`, and `canvas` objects;
-     * anything missing is resolved here as a safety net — REST fetches for
-     * project/page (auth required), direct HTTP for the canvas via its IIIF
-     * id on `page.target`.
+     * Accept the combined populated-bundle from the parent (assembled by
+     * `MessageHandler` from `TPEN_POPULATED_PROJECT` + `TPEN_POPULATED_PAGE`).
+     * Any field that didn't arrive is resolved here as a safety net — REST
+     * fetches for project/page (auth required), direct HTTP for the canvas
+     * via its IIIF id on `page.target`.
      * @param {{ project: any, page: any, canvas: any, currentLineId: string|null }} payload
      */
     async acceptContext(payload) {
@@ -161,7 +162,7 @@ export class PromptsApp {
 
     /**
      * Update the current line id on the rendered workspace. Called when the
-     * parent sends `UPDATE_CURRENT_LINE` in response to line navigation.
+     * parent sends `UPDATE_CURRENT_LINE` on line navigation.
      * @param {string|null} lineId full line IRI or null.
      */
     updateCurrentLine(lineId) {

--- a/main.js
+++ b/main.js
@@ -1,10 +1,12 @@
 /**
  * @file TPEN-Prompts orchestrator.
  *
- * Iframed mode: the parent pushes one `TPEN_CONTEXT` payload on iframe load
- * carrying the fully-hydrated `project`, `page`, and `canvas` objects. The
- * child renders directly from that payload — no REST round-trips, no request/
- * reply handshake. The `TPEN_ID_TOKEN` flow remains user-gated and separate.
+ * Iframed mode: the parent pushes a lean `TPEN_CONTEXT` payload on iframe
+ * load (project identity + URIs only). Prompt templates need fully-hydrated
+ * project/page/canvas objects, so on receipt of `TPEN_CONTEXT` we send
+ * `REQUEST_HYDRATED_CONTEXT` upstream; the parent replies with
+ * `TPEN_HYDRATED_CONTEXT` and the child renders from that payload.
+ * The `TPEN_ID_TOKEN` flow remains user-gated and separate.
  *
  * Standalone mode: reads URL params, fetches project (+ optionally page) from
  * the TPEN services API, resolves layer/column/line from the project graph.
@@ -36,17 +38,18 @@ export class PromptsApp {
 
     /**
      * Bootstrap the app. Iframed: show an awaiting screen and wait for the
-     * parent to push `TPEN_CONTEXT`. Standalone: render the id-entry form
-     * (or load directly when `projectID` is in the URL).
+     * parent to push `TPEN_CONTEXT`, then request `TPEN_HYDRATED_CONTEXT`.
+     * Standalone: render the id-entry form (or load directly when
+     * `projectID` is in the URL).
      * @returns {Promise<void>}
      */
     async init() {
         const iframed = window.parent !== window
 
         // Paint the awaiting screen SYNCHRONOUSLY, before any await. Otherwise
-        // a `TPEN_CONTEXT` message that lands during `await initTemplates()`
-        // renders the workspace, and then this init() continuation silently
-        // overwrites it with the awaiting screen.
+        // a `TPEN_HYDRATED_CONTEXT` message that lands during
+        // `await initTemplates()` renders the workspace, and then this init()
+        // continuation silently overwrites it with the awaiting screen.
         if (iframed) {
             clearStoredToken()
             this.token = null
@@ -55,6 +58,12 @@ export class PromptsApp {
                 showAuthButton: true,
                 onRequestAuth: () => this.messages.requestAuthToken()
             })
+            // Request the hydrated payload eagerly. If the parent has already
+            // sent TPEN_CONTEXT before we wired up the listener, this kicks
+            // off the hydration handshake. If the listener fires first, the
+            // TPEN_CONTEXT branch will also request hydration — duplicate
+            // requests are cheap and idempotent on the parent side.
+            this.messages.requestHydratedContext()
         }
 
         await initTemplates()
@@ -92,11 +101,11 @@ export class PromptsApp {
     }
 
     /**
-     * Accept a `TPEN_CONTEXT` payload from the parent. The payload is expected
-     * to carry hydrated `project`, `page`, and `canvas` objects; anything
-     * missing is resolved here as a safety net — REST fetches for project/page
-     * (auth required), direct HTTP for the canvas via its IIIF id on
-     * `page.target`.
+     * Accept a `TPEN_HYDRATED_CONTEXT` payload from the parent. The payload
+     * is expected to carry hydrated `project`, `page`, and `canvas` objects;
+     * anything missing is resolved here as a safety net — REST fetches for
+     * project/page (auth required), direct HTTP for the canvas via its IIIF
+     * id on `page.target`.
      * @param {{ project: any, page: any, canvas: any, currentLineId: string|null }} payload
      */
     async acceptContext(payload) {

--- a/main.js
+++ b/main.js
@@ -38,19 +38,15 @@ export class PromptsApp {
     }
 
     /**
-     * Bootstrap the app. Iframed: show an awaiting screen and wait for the
-     * parent to push `TPEN_CONTEXT`, then request the populated project/page
-     * pair. Standalone: render the id-entry form (or load directly when
-     * `projectID` is in the URL).
+     * Bootstrap the app.
      * @returns {Promise<void>}
      */
     async init() {
         const iframed = window.parent !== window
 
-        // Paint the awaiting screen SYNCHRONOUSLY, before any await. Otherwise
-        // a populated-bundle flush that lands during `await initTemplates()`
-        // renders the workspace, and then this init() continuation silently
-        // overwrites it with the awaiting screen.
+        // Paint synchronously before initTemplates() awaits — otherwise a
+        // populated-bundle flush that lands during the await silently
+        // overwrites this paint when init() resumes.
         if (iframed) {
             clearStoredToken()
             this.token = null

--- a/message-handler.js
+++ b/message-handler.js
@@ -1,18 +1,10 @@
 /**
  * @file postMessage consumer for the transcription parent frame.
  *
- * The parent pushes a lean `TPEN_CONTEXT` payload (project identity + URIs
- * only) unprompted on iframe load. TPEN-Prompts needs the fully-populated
- * project and page for prompt-template rendering, so on boot it sends
- * `REQUEST_POPULATED_PROJECT` and `REQUEST_POPULATED_PAGE`. The parent
- * answers with `TPEN_POPULATED_PROJECT` and `TPEN_POPULATED_PAGE`; both
- * replies are accumulated, and once both have arrived we hand the bundle
- * to `app.acceptContext`.
- *
- * Line navigation arrives as `UPDATE_CURRENT_LINE` deltas. The token is
- * separate and user-gated: clicking the consent button sends
- * `REQUEST_TPEN_ID_TOKEN` upstream, and the parent replies with
- * `TPEN_ID_TOKEN`.
+ * Routes inbound messages from the TPEN parent into the `PromptsApp`
+ * orchestrator. The parent's lean `TPEN_CONTEXT` boot payload triggers a
+ * follow-up request for the populated project + page pair (which the
+ * prompt templates need); other messages are straight pass-through.
  *
  * Replies are aimed at `parentOrigin`, captured from the first inbound
  * message; before any inbound arrives, `CONFIG.interfacesURL` is used

--- a/message-handler.js
+++ b/message-handler.js
@@ -1,11 +1,16 @@
 /**
  * @file postMessage consumer for the transcription parent frame.
  *
- * The parent pushes `TPEN_CONTEXT` unprompted on iframe load, carrying the
- * hydrated `project`, `page`, and `canvas` objects. Line navigation arrives
- * as `UPDATE_CURRENT_LINE` deltas. The token is separate and user-gated:
- * clicking the consent button sends `REQUEST_TPEN_ID_TOKEN` upstream, and
- * the parent replies with `TPEN_ID_TOKEN`.
+ * The parent pushes a lean `TPEN_CONTEXT` payload (project identity + URIs
+ * only) unprompted on iframe load. TPEN-Prompts needs the fully-hydrated
+ * project and page for prompt-template rendering, so on boot it sends a
+ * `REQUEST_HYDRATED_CONTEXT` reply and the parent answers with
+ * `TPEN_HYDRATED_CONTEXT` carrying the hydrated objects.
+ *
+ * Line navigation arrives as `UPDATE_CURRENT_LINE` deltas. The token is
+ * separate and user-gated: clicking the consent button sends
+ * `REQUEST_TPEN_ID_TOKEN` upstream, and the parent replies with
+ * `TPEN_ID_TOKEN`.
  *
  * Replies are aimed at `parentOrigin`, captured from the first inbound
  * message; before any inbound arrives, `CONFIG.interfacesURL` is used
@@ -44,6 +49,11 @@ export class MessageHandler {
                 this.app.acceptAuth({ token: data.idToken ?? null })
                 break
             case 'TPEN_CONTEXT':
+                // Lean payload (project identity + URIs). Templates wait for
+                // TPEN_HYDRATED_CONTEXT, so we just request hydration here.
+                this.requestHydratedContext()
+                break
+            case 'TPEN_HYDRATED_CONTEXT':
                 this.app.acceptContext(data).catch(err => console.error('acceptContext failed', err))
                 break
             case 'UPDATE_CURRENT_LINE':
@@ -71,4 +81,7 @@ export class MessageHandler {
 
     /** Ask the parent frame to send `TPEN_ID_TOKEN`. */
     requestAuthToken() { return this.#postToParent({ type: 'REQUEST_TPEN_ID_TOKEN' }) }
+
+    /** Ask the parent frame to send `TPEN_HYDRATED_CONTEXT`. */
+    requestHydratedContext() { return this.#postToParent({ type: 'REQUEST_HYDRATED_CONTEXT' }) }
 }

--- a/message-handler.js
+++ b/message-handler.js
@@ -2,10 +2,12 @@
  * @file postMessage consumer for the transcription parent frame.
  *
  * The parent pushes a lean `TPEN_CONTEXT` payload (project identity + URIs
- * only) unprompted on iframe load. TPEN-Prompts needs the fully-hydrated
- * project and page for prompt-template rendering, so on boot it sends a
- * `REQUEST_HYDRATED_CONTEXT` reply and the parent answers with
- * `TPEN_HYDRATED_CONTEXT` carrying the hydrated objects.
+ * only) unprompted on iframe load. TPEN-Prompts needs the fully-populated
+ * project and page for prompt-template rendering, so on boot it sends
+ * `REQUEST_POPULATED_PROJECT` and `REQUEST_POPULATED_PAGE`. The parent
+ * answers with `TPEN_POPULATED_PROJECT` and `TPEN_POPULATED_PAGE`; both
+ * replies are accumulated, and once both have arrived we hand the bundle
+ * to `app.acceptContext`.
  *
  * Line navigation arrives as `UPDATE_CURRENT_LINE` deltas. The token is
  * separate and user-gated: clicking the consent button sends
@@ -33,6 +35,14 @@ export class MessageHandler {
         this.app = app
         /** Origin of the first inbound message; used as targetOrigin for replies. */
         this.parentOrigin = null
+        /**
+         * Accumulator for the two-part populated reply bundle. Filled by the
+         * `TPEN_POPULATED_PROJECT` and `TPEN_POPULATED_PAGE` cases; once
+         * both halves are present we hand the bundle to `acceptContext` and
+         * clear it. Re-fills overwrite the previous value (the parent is
+         * authoritative on each new request).
+         */
+        this.populated = { project: null, page: null, canvas: null, currentLineId: null, hasProject: false, hasPage: false }
         window.addEventListener('message', (event) => this.handle(event))
     }
 
@@ -50,11 +60,20 @@ export class MessageHandler {
                 break
             case 'TPEN_CONTEXT':
                 // Lean payload (project identity + URIs). Templates wait for
-                // TPEN_HYDRATED_CONTEXT, so we just request hydration here.
-                this.requestHydratedContext()
+                // the populated reply pair, so we just request both here.
+                this.requestPopulatedContext()
                 break
-            case 'TPEN_HYDRATED_CONTEXT':
-                this.app.acceptContext(data).catch(err => console.error('acceptContext failed', err))
+            case 'TPEN_POPULATED_PROJECT':
+                this.populated.project = data.project ?? null
+                this.populated.hasProject = true
+                this.#flushPopulatedIfReady()
+                break
+            case 'TPEN_POPULATED_PAGE':
+                this.populated.page = data.page ?? null
+                this.populated.canvas = data.canvas ?? null
+                this.populated.currentLineId = data.currentLineId ?? null
+                this.populated.hasPage = true
+                this.#flushPopulatedIfReady()
                 break
             case 'UPDATE_CURRENT_LINE':
                 this.app.updateCurrentLine(data.currentLineId ?? null)
@@ -62,6 +81,20 @@ export class MessageHandler {
             default:
                 break
         }
+    }
+
+    /**
+     * Hand the accumulated populated bundle to `acceptContext` once both the
+     * project and page replies have arrived. Resets the `has*` flags so a
+     * subsequent re-request flows through the same gate cleanly.
+     */
+    #flushPopulatedIfReady() {
+        if (!this.populated.hasProject || !this.populated.hasPage) return
+        const { project, page, canvas, currentLineId } = this.populated
+        this.populated.hasProject = false
+        this.populated.hasPage = false
+        this.app.acceptContext({ project, page, canvas, currentLineId })
+            .catch(err => console.error('acceptContext failed', err))
     }
 
     /**
@@ -82,6 +115,13 @@ export class MessageHandler {
     /** Ask the parent frame to send `TPEN_ID_TOKEN`. */
     requestAuthToken() { return this.#postToParent({ type: 'REQUEST_TPEN_ID_TOKEN' }) }
 
-    /** Ask the parent frame to send `TPEN_HYDRATED_CONTEXT`. */
-    requestHydratedContext() { return this.#postToParent({ type: 'REQUEST_HYDRATED_CONTEXT' }) }
+    /**
+     * Ask the parent frame to send the populated project + page pair. The
+     * project carries the full graph (layers/pages/columns/members); the
+     * page carries items hydrated to full Annotations plus the canvas.
+     */
+    requestPopulatedContext() {
+        this.#postToParent({ type: 'REQUEST_POPULATED_PROJECT' })
+        this.#postToParent({ type: 'REQUEST_POPULATED_PAGE' })
+    }
 }

--- a/message-handler.js
+++ b/message-handler.js
@@ -77,14 +77,14 @@ export class MessageHandler {
 
     /**
      * Hand the accumulated populated bundle to `acceptContext` once both the
-     * project and page replies have arrived. Resets the `has*` flags so a
-     * subsequent re-request flows through the same gate cleanly.
+     * project and page replies have arrived. Fully resets the accumulator so
+     * a subsequent re-request can't surface a stale field if the gate is ever
+     * loosened.
      */
     #flushPopulatedIfReady() {
         if (!this.populated.hasProject || !this.populated.hasPage) return
         const { project, page, canvas, currentLineId } = this.populated
-        this.populated.hasProject = false
-        this.populated.hasPage = false
+        this.populated = { project: null, page: null, canvas: null, currentLineId: null, hasProject: false, hasPage: false }
         this.app.acceptContext({ project, page, canvas, currentLineId })
             .catch(err => console.error('acceptContext failed', err))
     }


### PR DESCRIPTION
## Summary

Align TPEN-Prompts with the canonical TPEN messaging contract. The lean `TPEN_CONTEXT` boot payload doesn't carry the populated project/page/canvas objects this tool needs for prompt-template rendering, so on receipt of `TPEN_CONTEXT` it now sends `REQUEST_POPULATED_PROJECT` and `REQUEST_POPULATED_PAGE` upstream and renders once both `TPEN_POPULATED_PROJECT` and `TPEN_POPULATED_PAGE` replies have arrived. The full contract is defined in CenterForDigitalHumanities/TPEN-interfaces#564.

## Changes

- `message-handler.js`
  - New `TPEN_POPULATED_PROJECT` and `TPEN_POPULATED_PAGE` cases. The handler accumulates both halves into a `populated` bag and only calls `app.acceptContext({ project, page, canvas, currentLineId })` once both have landed — so the workspace renders once, with the full bundle.
  - `TPEN_CONTEXT` case now triggers `requestPopulatedContext()`, which posts both `REQUEST_POPULATED_PROJECT` and `REQUEST_POPULATED_PAGE`.
  - The previous `requestHydratedContext()` / `TPEN_HYDRATED_CONTEXT` path is removed.
- `main.js`
  - Module docstring and `acceptContext` JSDoc updated to describe the split-then-bundle boot flow.

## Coordinated cut

Hard cut, all PRs must merge together. Full contract and other PRs:

- TPEN-interfaces (authority): https://github.com/CenterForDigitalHumanities/TPEN-interfaces/pull/564
- TPEN-services: https://github.com/CenterForDigitalHumanities/TPEN-services/pull/519
- Page-Viewer: https://github.com/CenterForDigitalHumanities/Page-Viewer/pull/14
- Preview-Transcription: https://github.com/CenterForDigitalHumanities/Preview-Transcription/pull/6
- Line-Breaking: https://github.com/CenterForDigitalHumanities/Line-Breaking/pull/2
- Compare-Pages: https://github.com/CenterForDigitalHumanities/Compare-Pages/pull/3

## Test plan

Developer-validated locally on 2026-05-08 against CenterForDigitalHumanities/TPEN-interfaces#564 on `:4000`, services on `:3012`:

- [x] In TPEN-interfaces (`jekyll s`), add TPEN-Prompts to a project's tools. Open `/transcribe`.
- [x] Awaiting screen renders, then templates render once both populated replies have arrived.
- [x] DevTools: exactly one `TPEN_CONTEXT` (parent → tool), then exactly one `REQUEST_POPULATED_PROJECT` and one `REQUEST_POPULATED_PAGE` (tool → parent), and one `TPEN_POPULATED_PROJECT` + one `TPEN_POPULATED_PAGE` reply (parent → tool). No re-requests on the same boot.
- [x] Click a line in the parent → `UPDATE_CURRENT_LINE` arrives and the tool's current-line state updates.
- [x] Click "Authenticate" in the awaiting screen → outbound `REQUEST_TPEN_ID_TOKEN`, parent toast confirms, inbound `TPEN_ID_TOKEN`, prompts use the token.
- [x] Standalone mode (open the tool URL with `?projectID=...`) still works.
- [x] Generated prompt copies to clipboard. The async Clipboard API is denied by the parent's iframe Permissions Policy (no `allow="clipboard-write"` on the parent's `<iframe>` element), so the existing `document.execCommand('copy')` fallback engages and copy succeeds. The `[Violation]` console warning is benign — kept the fallback rather than expanding the contract scope.